### PR TITLE
4.8.8.2, version submitted to App Store

### DIFF
--- a/Classes/LatestChatty2AppDelegate.h
+++ b/Classes/LatestChatty2AppDelegate.h
@@ -19,7 +19,7 @@
 #import "IIViewDeckController.h"
 #import "SloppySwiper.h"
 
-@interface LatestChatty2AppDelegate : NSObject <UIApplicationDelegate, UIAlertViewDelegate, UISplitViewControllerDelegate> {
+@interface LatestChatty2AppDelegate : NSObject <UIApplicationDelegate, UIAlertViewDelegate, UISplitViewControllerDelegate, SFSafariViewControllerDelegate> {
     UIWindow *window;
     UINavigationController *navigationController;
     UINavigationController *contentNavigationController;
@@ -63,5 +63,7 @@
 - (BOOL)isSplitView;
 - (BOOL)isForceTouchEnabled;
 - (void)setNetworkActivityIndicatorVisible:(BOOL)setVisible;
+- (void)handleViewController:(UIViewController *)viewController;
+- (void)presentViewController:(UIViewController *)viewController presentModally:(BOOL)modal;
 	
 @end

--- a/Classes/LatestChatty2AppDelegate.m
+++ b/Classes/LatestChatty2AppDelegate.m
@@ -953,7 +953,7 @@ static NSString *kWoggleBaseUrl = @"http://www.woggle.net/lcappnotification";
         [alertController addAction:okAction];
         
         [self presentViewController:alertController presentModally:NO];
-//        [defaults setBool:NO forKey:@"guidelines.firstLaunch"];
+        [defaults setBool:NO forKey:@"guidelines.firstLaunch"];
     }
 }
 

--- a/Classes/LatestChatty2AppDelegate.m
+++ b/Classes/LatestChatty2AppDelegate.m
@@ -12,7 +12,6 @@
 #import "NoContentController.h"
 #import "IIViewDeckController.h"
 @import Firebase;
-@import Fabric;
 @import Crashlytics;
 
 static NSString *kWoggleBaseUrl = @"http://www.woggle.net/lcappnotification";

--- a/Classes/LatestChatty2AppDelegate.m
+++ b/Classes/LatestChatty2AppDelegate.m
@@ -228,6 +228,7 @@ static NSString *kWoggleBaseUrl = @"http://www.woggle.net/lcappnotification";
                                      [NSNumber numberWithBool:YES], @"saveSearches",
                                      [NSNumber numberWithBool:YES], @"swipeBack",
                                      [NSNumber numberWithBool:YES], @"lolTags",
+                                     [NSNumber numberWithBool:YES], @"guidelines.firstLaunch",
                                      nil];
     [defaults registerDefaults:defaultSettings];
     
@@ -248,7 +249,7 @@ static NSString *kWoggleBaseUrl = @"http://www.woggle.net/lcappnotification";
 
     [defaults synchronize];
     // fire synchronize on app load to sync settings from iCloud
-    // freshing install: will pull all existing iCloud user settings down and put into user defaults database
+    // fresh install: will pull all existing iCloud user settings down and put into user defaults database
     // existing install: will pull down any changes in the iCloud user settings and sync to the user defaults database
     [store synchronize];
     
@@ -259,6 +260,7 @@ static NSString *kWoggleBaseUrl = @"http://www.woggle.net/lcappnotification";
     }
     
     [self pushRegistration];
+    [self promptGuidelines];
     
     [window makeKeyAndVisible];
     
@@ -660,6 +662,20 @@ static NSString *kWoggleBaseUrl = @"http://www.woggle.net/lcappnotification";
     viewController = nil;
 }
 
+- (void)presentViewController:(UIViewController *)viewController presentModally:(BOOL)modal {
+    if ([self isPadDevice]) {
+        if (modal) {
+            [self.slideOutViewController presentViewController:viewController animated:YES completion:nil];
+        } else {
+            [self.contentNavigationController presentViewController:viewController animated:YES completion:nil];
+        }
+    } else {
+        [self.navigationController presentViewController:viewController animated:YES completion:nil];
+    }
+    
+    viewController = nil;
+}
+
 #pragma mark - Appearance customizations
 
 // Custom appearance settings for UIKit items
@@ -897,6 +913,47 @@ static NSString *kWoggleBaseUrl = @"http://www.woggle.net/lcappnotification";
 - (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex {
     if (buttonIndex == 1) {
         [self handleViewController:[self makeThreadViewController]];
+    }
+}
+
+#pragma mark - Guidelines on first launch
+
+-(void)promptGuidelines {
+    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
+    
+    if ([defaults boolForKey:@"guidelines.firstLaunch"] == YES) {
+        UIAlertController *alertController = [UIAlertController
+                                              alertControllerWithTitle:@"Guidelines"
+                                              message:@"By using LatestChatty, you agree to all Shacknews community posting guidelines."
+                                              preferredStyle:UIAlertControllerStyleAlert];
+        
+        UIAlertAction *viewAction = [UIAlertAction
+                                     actionWithTitle:@"View"
+                                     style:UIAlertActionStyleDefault
+                                     handler:^(UIAlertAction *action)
+                                     {
+                                         // push guidelines webview
+                                         NSString *urlString = @"https://www.shacknews.com/guidelines";
+                                         SFSafariViewController *svc = [[SFSafariViewController alloc] initWithURL:[NSURL URLWithString:urlString]];
+                                         [svc setModalTransitionStyle:UIModalTransitionStyleCoverVertical];
+                                         [svc setModalPresentationStyle:UIModalPresentationFormSheet];
+                                         [svc setDelegate:self];
+                                         [svc setPreferredBarTintColor:[UIColor lcBarTintColor]];
+                                         [svc setPreferredControlTintColor:[UIColor whiteColor]];
+                                         [svc setModalPresentationCapturesStatusBarAppearance:YES];
+                                         [self presentViewController:svc presentModally:YES];
+                                     }];
+        
+        UIAlertAction *okAction = [UIAlertAction
+                                   actionWithTitle:@"OK"
+                                   style:UIAlertActionStyleDefault
+                                   handler:nil];
+        
+        [alertController addAction:viewAction];
+        [alertController addAction:okAction];
+        
+        [self presentViewController:alertController presentModally:NO];
+//        [defaults setBool:NO forKey:@"guidelines.firstLaunch"];
     }
 }
 

--- a/Classes/SendMessageViewController.h
+++ b/Classes/SendMessageViewController.h
@@ -23,6 +23,7 @@
 @property (strong, nonatomic) UITextField *recipient;
 @property (strong, nonatomic) UITextField *subject;
 @property (strong, nonatomic) UITextView *body;
+@property bool reportMessage;
 
 - (void)showActivityIndicator;
 - (void)setupReply;
@@ -31,5 +32,6 @@
 
 - (id)initWithRecipient:(NSString *)aRecipient;
 - (id)initWithMessage:(Message *)aMessage;
+- (id)initWithReportBody:(NSString *)aBody;
 
 @end

--- a/Classes/SendMessageViewController.m
+++ b/Classes/SendMessageViewController.m
@@ -40,6 +40,18 @@
     return self;
 }
 
+- (id)initWithReportBody:(NSString *)aBody {
+    self = [self initWithNib];
+    
+    self.title = @"Report";
+    self.recipientString = @"Duke Nuked";
+    self.subjectString = @"Reporting Author of Post";
+    self.bodyString = aBody;
+    self.reportMessage = YES;
+    
+    return self;
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     
@@ -56,7 +68,9 @@
     [self.subject setText:self.subjectString];
     [self.body setText:self.bodyString];
     if (self.bodyString) {
-        [self setupReply];
+        if (!self.reportMessage) {
+            [self setupReply];
+        }
         self.navigationItem.rightBarButtonItem.enabled = YES;
     }
     

--- a/Classes/SettingsViewController.m
+++ b/Classes/SettingsViewController.m
@@ -521,21 +521,7 @@ static NSString *kWoggleBaseUrl = @"http://www.woggle.net/lcappnotification";
     [svc setPreferredControlTintColor:[UIColor whiteColor]];
     [svc setModalPresentationCapturesStatusBarAppearance:YES];
     
-    if ([[LatestChatty2AppDelegate delegate] isPadDevice]) {
-        [[self showingViewController] dismissViewControllerAnimated:NO completion:^{
-            [[self showingViewController] presentViewController:svc animated:YES completion:nil];
-        }];
-    } else {
-        [[self showingViewController] presentViewController:svc animated:YES completion:nil];
-    }
-}
-
-- (UIViewController *)showingViewController {
-    if ([[LatestChatty2AppDelegate delegate] isPadDevice]) {
-        return [LatestChatty2AppDelegate delegate].slideOutViewController;
-    } else {
-        return self;
-    }
+    [self presentViewController:svc animated:YES completion:nil];
 }
 
 #pragma mark Table view methods

--- a/Classes/SettingsViewController.m
+++ b/Classes/SettingsViewController.m
@@ -514,6 +514,8 @@ static NSString *kWoggleBaseUrl = @"http://www.woggle.net/lcappnotification";
 
 - (void)safariViewControllerForURL:(NSURL *)url {
     SFSafariViewController *svc = [[SFSafariViewController alloc] initWithURL:url];
+    [svc setModalTransitionStyle:UIModalTransitionStyleCoverVertical];
+    [svc setModalPresentationStyle:UIModalPresentationFormSheet];
     [svc setDelegate:self];
     [svc setPreferredBarTintColor:[UIColor lcBarTintColor]];
     [svc setPreferredControlTintColor:[UIColor whiteColor]];

--- a/Classes/ThreadViewController.m
+++ b/Classes/ThreadViewController.m
@@ -685,7 +685,7 @@
                                                   delegate:self
                                          cancelButtonTitle:@"Cancel"
                                     destructiveButtonTitle:nil
-                                         otherButtonTitles:@"Search for Posts", @"Send a Message", nil];
+                                         otherButtonTitles:@"Search for Posts", @"Send a Message", @"Report", nil];
     
     if ([[LatestChatty2AppDelegate delegate] isPadDevice]) {
         [dialog showInView:[LatestChatty2AppDelegate delegate].slideOutViewController.view];
@@ -893,6 +893,12 @@
         // start a shackmessage with this author as the recipient
         if (buttonIndex == 1) {
             viewController = [[SendMessageViewController alloc] initWithRecipient:author];
+        }
+        // start a shackmessage to duke nuked reporting this author/post
+        if (buttonIndex == 2) {
+            unsigned long pid = (unsigned long)postId;
+            NSString *body = [NSString stringWithFormat:@"I would like to report user \"%@\", author of post http://www.shacknews.com/chatty?id=%lu#item_%lu for not adhering to the Shacknews guidelines.", author, pid, pid];
+            viewController = [[SendMessageViewController alloc] initWithReportBody:body];
         }
         
         // push the resulting view controller

--- a/Info.plist
+++ b/Info.plist
@@ -32,7 +32,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>4.8.8.1</string>
+	<string>4.8.8.2</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>

--- a/LatestChatty2.xcodeproj/project.pbxproj
+++ b/LatestChatty2.xcodeproj/project.pbxproj
@@ -1248,14 +1248,14 @@
 			};
 			buildConfigurationList = C01FCF4E08A954540054247B /* Build configuration list for PBXProject "LatestChatty2" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 1;
 			knownRegions = (
-				English,
-				Japanese,
-				French,
-				German,
 				en,
+				ja,
+				Base,
+				fr,
+				de,
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;

--- a/LatestChatty2.xcodeproj/xcshareddata/xcschemes/LatestChatty2.xcscheme
+++ b/LatestChatty2.xcodeproj/xcshareddata/xcschemes/LatestChatty2.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1010"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,12 @@ Requires iOS 8 minimum!
 
 4.8.8
 ====
-- Conversion to Firebase
-- Clean up deprecations
+- Analytics migration
+- Code cleanup
+- Tweaked default viewable post category filters
+- User must accept Guidelines on first app launch
+- Guidelines accessible in Settings view
+- Tap author name in thread view to report user/post via Shack Message
 
 4.8.7
 ====

--- a/Settings.bundle/Root.plist
+++ b/Settings.bundle/Root.plist
@@ -12,7 +12,7 @@
 		</dict>
 		<dict>
 			<key>DefaultValue</key>
-			<string>4.8.8.1</string>
+			<string>4.8.8.2</string>
 			<key>Key</key>
 			<string>version_preference</string>
 			<key>Title</key>


### PR DESCRIPTION
Version attempts to resolve Apple's [issue with the app](https://github.com/latestchatty/latest-chatty-ios/issues/148)

- UIAlertController prompts user they are agreeing to Shack Guidelines by using the app
- Tap author name in thread view to report user/post via Shack Message to Duke Nuked
- Off-topic, politics / religion, and stupid filter categories now defaulted to OFF for fresh app install with no existing iCloud settings being ported over
- Added link to Shack Guidelines in "About" section of Settings view
- Additionally, cleaned up the remaining deprecations (only deprecated warnings now are from dependencies)
